### PR TITLE
Better separation between storage layer and translation layer

### DIFF
--- a/chainmeta_reader/config/__init__.py
+++ b/chainmeta_reader/config/__init__.py
@@ -110,4 +110,4 @@ def load_config() -> Config:
 
 default_config = load_config()
 
-__all__ = [Config, default_config]
+__all__ = ["Config", "default_config"]


### PR DESCRIPTION
Metadata can exists in 3 format:
- custom schema
- common  schema
- flattened db record

This change is to ensure the metadata translation only happens as follows:
`custom schema <-> common schema <-> db record`

Custom schema and storage layer are separated by design