### PR TITLE
Add detect-private-key pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
   - id: debug-statements
   - id: end-of-file-fixer
   - id: trailing-whitespace
+  - id: detect-private-key
 - repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:


### PR DESCRIPTION
It doesn't work with api_tokens.json, but still worthing adding it for other cases