### PR TITLE
add new from, to and metadata column via dbmigration

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -60,7 +60,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = mysql+pymysql://root:test@localhost/mysql
+sqlalchemy.url = mysql+pymysql://{DB-USR}:{DB-PWD}@{DB-HOST}?ssl_ca=/etc/ssl/certs/ca-certificates.crt
 
 
 [post_write_hooks]

--- a/dbmigration/env.py
+++ b/dbmigration/env.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from logging.config import fileConfig
 
 from alembic import context
@@ -20,7 +21,6 @@ from sqlalchemy import engine_from_config, pool
 # access to the values within the .ini file in use.
 config = context.config
 
-import os
 
 db_url = os.environ["DBURL"]
 config.set_main_option("sqlalchemy.url", db_url)

--- a/dbmigration/env.py
+++ b/dbmigration/env.py
@@ -20,6 +20,11 @@ from sqlalchemy import engine_from_config, pool
 # access to the values within the .ini file in use.
 config = context.config
 
+import os
+
+db_url = os.environ["DBURL"]
+config.set_main_option("sqlalchemy.url", db_url)
+
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:

--- a/dbmigration/versions/e7429574614a_add_gmt_create_and_gmt_modified.py
+++ b/dbmigration/versions/e7429574614a_add_gmt_create_and_gmt_modified.py
@@ -1,0 +1,44 @@
+"""add gmt_create and gmt_modified
+
+Revision ID: e7429574614a
+Revises: 449a20c2a993
+Create Date: 2024-03-25 16:49:23.941699
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e7429574614a"
+down_revision = "449a20c2a993"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chainmeta",
+        sa.Column(
+            "gmt_create", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+    )
+    op.add_column(
+        "chainmeta",
+        sa.Column(
+            "gmt_modified",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(op.f("idx_source"), "chainmeta", ["source"])
+    op.create_index(op.f("idx_modified"), "chainmeta", ["gmt_modified"])
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("idx_modified"), "chainmeta")
+    op.drop_index(op.f("idx_source"), "chainmeta")
+    op.drop_column("chainmeta", "gmt_modified")
+    op.drop_column("chainmeta", "gmt_create")

--- a/dbmigration/versions/e7429574614a_add_gmt_create_and_gmt_modified.py
+++ b/dbmigration/versions/e7429574614a_add_gmt_create_and_gmt_modified.py
@@ -1,3 +1,16 @@
+# Copyright 2023 The chainmetareader Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """add gmt_create and gmt_modified
 
 Revision ID: e7429574614a
@@ -6,9 +19,8 @@ Create Date: 2024-03-25 16:49:23.941699
 
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "e7429574614a"

--- a/dbmigration/versions/f1e13c4fa803_add_from_to_and_additional_info.py
+++ b/dbmigration/versions/f1e13c4fa803_add_from_to_and_additional_info.py
@@ -1,0 +1,32 @@
+"""add from to and additional info
+
+Revision ID: f1e13c4fa803
+Revises: e7429574614a
+Create Date: 2024-03-25 17:08:08.491118
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f1e13c4fa803"
+down_revision = "e7429574614a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chainmeta",
+        sa.Column("from", sa.DateTime, nullable=True, server_default=sa.func.now()),
+    )
+    op.add_column("chainmeta", sa.Column("to", sa.DateTime, nullable=True))
+    op.add_column("chainmeta", sa.Column("metadata", sa.JSON, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("chainmeta", "metadata")
+    op.drop_column("chainmeta", "to")
+    op.drop_column("chainmeta", "from")

--- a/dbmigration/versions/f1e13c4fa803_add_from_to_and_additional_info.py
+++ b/dbmigration/versions/f1e13c4fa803_add_from_to_and_additional_info.py
@@ -1,3 +1,16 @@
+# Copyright 2023 The chainmetareader Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """add from to and additional info
 
 Revision ID: f1e13c4fa803
@@ -6,9 +19,8 @@ Create Date: 2024-03-25 17:08:08.491118
 
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "f1e13c4fa803"

--- a/upload.py
+++ b/upload.py
@@ -27,7 +27,6 @@ logging.basicConfig(level=logging.DEBUG)
 @click.command()
 @click.argument("filename", type=click.Path(exists=True))
 def upload(filename: str):
-
     folder_path = Path(filename).resolve().parent
     with open(filename) as f:
         metadata = load(f, artifact_base_path=folder_path)


### PR DESCRIPTION
Add 3 new fields:
- from: optional field to describe when is the label valid from
- to: optional field to describe when is the label valid till
- metadata: additional metadata for the the label. It's meant to be flexible to hold label specific information.

Also added a dbmigration script to add `gmt_create` and `gmt_modified` field. 
These 2 fields are already added to the DB without dbmigration. And this change will bring DB state and dbmigration state in sync.